### PR TITLE
Fixed params and query params

### DIFF
--- a/backbone.middleware.js
+++ b/backbone.middleware.js
@@ -74,6 +74,16 @@
   };
 
   /**
+   * Removes the queryparams from the fragment
+   *
+   * @param  {String} fragment
+   * @return {String}
+   */
+  function removeQueryParams(frm) {
+    return frm.replace(/(\?(.*))?$/, '');
+  }
+
+  /**
    * Populates a params object
    *
    * @return {Function}
@@ -81,9 +91,10 @@
   Middleware.params = function () {
     var parameters = _.toArray(arguments);
     return function params() {
-      this.params = _.object(parameters, _.toArray(arguments));
+      var args = _.map(_.compact(_.toArray(arguments)), removeQueryParams);
+      this.params = _.object(parameters, args);
       params.next();
-    }
+    };
   };
 
   Backbone.Middleware = Middleware;

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "backbone.middleware",
   "description": "Routers are fine, but sometime you need moar.",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "author": "Pau ramon <masylum@gmail.com>",
   "keywords": ["backbone", "middleware", "router", "ender", "teambox"],
   "repository": {"type": "git", "url": "git@github.com:masylum/backbone.middleware.git"},


### PR DESCRIPTION
Filters out the queryparam part of the params, so urls like `foo.com/a/#!/tasks/2?sort=by_date` will work as expected. Before the fix, the `task_id` would be `2?sort=by_date` instead of `2`.
